### PR TITLE
013 Organise scripts

### DIFF
--- a/compose.portainer.yaml
+++ b/compose.portainer.yaml
@@ -1,6 +1,6 @@
 services:
   portainer:
-    image: portainer/portainer-ce:latest
+    image: portainer/portainer-ce:2.33.4
     container_name: homelab-portainer
     restart: unless-stopped
     ports:

--- a/scripts/backfill
+++ b/scripts/backfill
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+while true; do
+  echo "Enter the collection date (YYYY-MM-DD), or type 'exit' to stop:"
+  read COLLECTION_DATE
+
+  if [[ "$COLLECTION_DATE" == "exit" ]]; then
+    echo "Exiting..."
+    break
+  fi
+
+  echo "Enter bin colours that will be collected on this date (separated by space e.g. 'blue green'):"
+  read -a BIN_COLOURS
+
+  JSON_BIN_COLOURS=$(printf '%s\n' "${BIN_COLOURS[@]}" | jq -R . | jq -s .)
+
+  python src/data/backfill.py "$COLLECTION_DATE" "$JSON_BIN_COLOURS"
+
+  echo "----------"
+done

--- a/scripts/backfill
+++ b/scripts/backfill
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+set -e
+
+projectRoot="$(a="/$0"; a=${a%/*}; a=${a:-.}; a=${a#/}/; cd "$a/.." || return; pwd)"
+
+cd "${projectRoot}"
+
 while true; do
   echo "Enter the collection date (YYYY-MM-DD), or type 'exit' to stop:"
   read COLLECTION_DATE

--- a/scripts/start
+++ b/scripts/start
@@ -2,7 +2,9 @@
 
 set -e
 
-cd "$(dirname "$0")"
+projectRoot="$(a="/$0"; a=${a%/*}; a=${a:-.}; a=${a#/}/; cd "$a/.." || return; pwd)"
+
+cd "${projectRoot}"
 
 show_services() {
   echo

--- a/scripts/start
+++ b/scripts/start
@@ -16,9 +16,9 @@ show_services() {
   echo "all"
   echo
   echo "Usage examples:"
-  echo "./start cloudflared"
-  echo "./start cloudflared portainer"
-  echo "./start all"
+  echo "./scripts/start cloudflared"
+  echo "./scripts/start cloudflared portainer"
+  echo "./scripts/start all"
 }
 
 FILES=()

--- a/scripts/stop
+++ b/scripts/stop
@@ -2,7 +2,9 @@
 
 set -e
 
-cd "$(dirname "$0")"
+projectRoot="$(a="/$0"; a=${a%/*}; a=${a:-.}; a=${a#/}/; cd "$a/.." || return; pwd)"
+
+cd "${projectRoot}"
 
 show_services() {
   echo

--- a/scripts/stop
+++ b/scripts/stop
@@ -16,9 +16,9 @@ show_services() {
   echo "all"
   echo
   echo "Usage examples:"
-  echo "./stop cloudflared"
-  echo "./stop cloudflared portainer"
-  echo "./stop all"
+  echo "./scripts/stop cloudflared"
+  echo "./scripts/stop cloudflared portainer"
+  echo "./scripts/stop all"
 }
 
 FILES=()


### PR DESCRIPTION
- [ ] Add backfill script + check it works when `bin-it` app is running.
- [ ] Ensure `start` and `stop` scripts are still working as expected.
